### PR TITLE
datalake: Convert protobuf repeated fields into Arrow lists

### DIFF
--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -32,11 +32,13 @@ deb_deps=(
   cmake
   git
   golang
+  libarrow-dev
   libboost-all-dev
   libc-ares-dev
   libgssapi-krb5-2
   libkrb5-dev
   liblz4-dev
+  libparquet-dev
   libprotobuf-dev
   libprotoc-dev
   libre2-dev
@@ -71,6 +73,7 @@ fedora_deps=(
   golang
   hwloc-devel
   krb5-devel
+  libarrow-devel
   libxml2-devel
   libzstd-devel
   lksctp-tools-devel
@@ -82,6 +85,7 @@ fedora_deps=(
   numactl-devel
   openssl
   openssl-devel
+  parquet-libs-devel
   procps
   protobuf-devel
   python3
@@ -124,8 +128,14 @@ arch_deps=(
 
 case "$ID" in
   ubuntu | debian | pop)
-    apt-get update
-    DEBIAN_FRONTEND=noninteractive apt-get install -y "${deb_deps[@]}"
+    export DEBIAN_FRONTEND=noninteractive
+    apt update
+    apt install -y -V ca-certificates lsb-release wget
+    wget https://apache.jfrog.io/artifactory/arrow/$(lsb_release --id --short | tr 'A-Z' 'a-z')/apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb
+    apt install -y -V ./apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb
+    rm apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb
+    apt update
+    apt-get install -y "${deb_deps[@]}"
     if [[ $CLEAN_PKG_CACHE == true ]]; then
       rm -rf /var/lib/apt/lists/*
     fi

--- a/licenses/third_party.md
+++ b/licenses/third_party.md
@@ -9,6 +9,7 @@ please keep this up to date with every new library use.
 | :----------     | :------------                      |
 | abseil          | Apache License 2                   |
 | ada             | Apache License 2 / MIT             |
+| arrow           | Apache License 2 / MIT / Boost / BSD 2 & 3 clause / ZPL / LLVM / <https://github.com/apache/arrow/blob/main/LICENSE.txt> |
 | avro            | Apache License 2                   |
 | base64          | BSD 2                              |
 | boost libraries | Boost Software License Version 1.0 |

--- a/src/v/CMakeLists.txt
+++ b/src/v/CMakeLists.txt
@@ -129,6 +129,7 @@ add_subdirectory(compat)
 add_subdirectory(rp_util)
 add_subdirectory(resource_mgmt)
 add_subdirectory(migrations)
+add_subdirectory(datalake)
 
 option(ENABLE_GIT_VERSION "Build with Git metadata" OFF)
 

--- a/src/v/README.md
+++ b/src/v/README.md
@@ -14,6 +14,7 @@ compression            | utilities supporting compression/decompression of many 
 config                 | Redpanda cluster level and node level configuration options |
 container              | Generic Redpanda specific containers and data structures |
 crypto                 | Middleware library used to perform cryptographic operations |
+datalake               | Writing Redpanda data to Iceberg |
 features               | Cluster feature flags for rolling upgrades |
 finjector              | Failure injector framework for testing and correctness |
 hashing                | hashing utility adaptors often used in cryptography or checksumming |

--- a/src/v/datalake/CMakeLists.txt
+++ b/src/v/datalake/CMakeLists.txt
@@ -1,0 +1,20 @@
+find_package(Arrow REQUIRED)
+find_package(Parquet REQUIRED)
+find_package(Protobuf REQUIRED)
+
+
+v_cc_library(
+  NAME datalake
+  SRCS
+    protobuf_to_arrow_converter.cc
+    proto_to_arrow_scalar.cc
+    proto_to_arrow_struct.cc
+  DEPS
+    v::storage
+    Seastar::seastar
+    Arrow::arrow_shared
+    Parquet::parquet_shared
+    protobuf::libprotobuf
+)
+
+add_subdirectory(tests)

--- a/src/v/datalake/CMakeLists.txt
+++ b/src/v/datalake/CMakeLists.txt
@@ -7,6 +7,7 @@ v_cc_library(
   NAME datalake
   SRCS
     protobuf_to_arrow_converter.cc
+    proto_to_arrow_repeated.cc
     proto_to_arrow_scalar.cc
     proto_to_arrow_struct.cc
   DEPS

--- a/src/v/datalake/errors.h
+++ b/src/v/datalake/errors.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+#pragma once
+
+#include <stdexcept>
+namespace datalake {
+
+// TODO: Make an std::error_category instance for this
+enum class arrow_converter_status {
+    ok,
+
+    // User errors
+    parse_error,
+
+    // System Errors
+    internal_error,
+};
+
+class initialization_error : public std::runtime_error {
+public:
+    explicit initialization_error(const std::string& what_arg)
+      : std::runtime_error(what_arg) {}
+};
+
+} // namespace datalake

--- a/src/v/datalake/logger.h
+++ b/src/v/datalake/logger.h
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#pragma once
+
+#include "base/seastarx.h"
+
+#include <seastar/util/log.hh>
+
+namespace datalake {
+inline ss::logger datalake_log("datalake");
+} // namespace datalake

--- a/src/v/datalake/proto_to_arrow_interface.h
+++ b/src/v/datalake/proto_to_arrow_interface.h
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+#pragma once
+
+#include <arrow/api.h>
+#include <arrow/array/array_base.h>
+#include <arrow/type_fwd.h>
+
+#include <memory>
+#include <stdexcept>
+
+namespace google::protobuf {
+class Message;
+}
+
+namespace datalake::detail {
+
+// This interface is used to convert a set of Protobuf messages to an Arrow
+// Array. Proto messages are passed one-by-one along to this interface, and it
+// builds internal state representing the Arrow array. Finally, the `finish`
+// method returns the completed array.
+class proto_to_arrow_interface {
+public:
+    proto_to_arrow_interface(const proto_to_arrow_interface&) = delete;
+    proto_to_arrow_interface(proto_to_arrow_interface&&) = delete;
+    proto_to_arrow_interface& operator=(const proto_to_arrow_interface&)
+      = delete;
+    proto_to_arrow_interface& operator=(proto_to_arrow_interface&&) = delete;
+
+    proto_to_arrow_interface() = default;
+    virtual ~proto_to_arrow_interface() = default;
+
+    // Called on a struct message to parse an individual child field.
+    // We expect the given child field to match the type of the column
+    // represented by this converter. E.g. a proto_to_arrow_scalar<int32> would
+    // expect the column referred to by field_idx to be an int32 column.
+    virtual arrow::Status
+    add_child_value(const google::protobuf::Message*, int field_idx)
+      = 0;
+
+    /// Return an Arrow field descriptor for this Array. Used for building
+    /// A schema.
+    // The Arrow API is built around shared_ptr: the creation functions return
+    // shared pointers, and other expect them as arguments.
+    // TODO: investigate if we can change the shared_ptr type in Arrow to use
+    // ss::shared_ptr
+    virtual std::shared_ptr<arrow::Field> field(const std::string& name) = 0;
+
+    /// Return the underlying ArrayBuilder. Used when this is a child of another
+    /// Builder
+    virtual std::shared_ptr<arrow::ArrayBuilder> builder() = 0;
+
+    // Methods with defaults
+    virtual arrow::Status finish_batch() { return arrow::Status::OK(); }
+    std::shared_ptr<arrow::ChunkedArray> finish() {
+        return std::make_shared<arrow::ChunkedArray>(std::move(_values));
+    }
+
+protected:
+    arrow::Status _arrow_status;
+    arrow::ArrayVector _values;
+};
+
+} // namespace datalake::detail

--- a/src/v/datalake/proto_to_arrow_interface.h
+++ b/src/v/datalake/proto_to_arrow_interface.h
@@ -11,6 +11,7 @@
 
 #include <arrow/api.h>
 #include <arrow/array/array_base.h>
+#include <arrow/status.h>
 #include <arrow/type_fwd.h>
 
 #include <memory>
@@ -57,8 +58,9 @@ public:
     /// Builder
     virtual std::shared_ptr<arrow::ArrayBuilder> builder() = 0;
 
+    virtual arrow::Status finish_batch() = 0;
+
     // Methods with defaults
-    virtual arrow::Status finish_batch() { return arrow::Status::OK(); }
     std::shared_ptr<arrow::ChunkedArray> finish() {
         return std::make_shared<arrow::ChunkedArray>(std::move(_values));
     }

--- a/src/v/datalake/proto_to_arrow_repeated.cc
+++ b/src/v/datalake/proto_to_arrow_repeated.cc
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "datalake/proto_to_arrow_repeated.h"
+
+#include "datalake/logger.h"
+#include "datalake/proto_to_arrow_struct.h"
+
+#include <arrow/array/builder_base.h>
+#include <arrow/array/builder_nested.h>
+#include <arrow/scalar.h>
+#include <arrow/status.h>
+#include <arrow/type.h>
+#include <arrow/type_fwd.h>
+#include <google/protobuf/message.h>
+
+#include <memory>
+
+namespace datalake::detail {
+proto_to_arrow_repeated::proto_to_arrow_repeated(
+  const google::protobuf::FieldDescriptor* desc) {
+    // The documentation for ListBuilder is not very detailed. From the linked
+    // StackOverflow and some trial-and-error, it looks like it's used like
+    // this:
+    // 1. A ListBuilder is created with a shared pointer to another
+    // arrow::ArrayBuilder as a child.
+    // 2. *Before* adding elements to the child, call Append() on the
+    // ListBuilder.
+    // 3. Call Append(val) on the child builder in the normal way.
+    // 4. *Do not* call Finish() onthe child builder.
+    // 5. Call Finish() on the ListBuilder to get the array.
+    //
+    // https://stackoverflow.com/questions/78277111/is-there-a-way-to-nest-an-arrowarray-in-apache-arrow
+    _child_converter = make_converter(desc, true);
+    _builder = std::make_shared<arrow::ListBuilder>(
+      arrow::default_memory_pool(), _child_converter->builder());
+}
+
+arrow::Status proto_to_arrow_repeated::add_child_value(
+  const google::protobuf::Message* msg, int field_idx) {
+    if (!_arrow_status.ok()) {
+        return _arrow_status;
+    }
+    _arrow_status = _builder->Append();
+    if (!_arrow_status.ok()) {
+        return _arrow_status;
+    }
+    _arrow_status = _child_converter->add_child_value(msg, field_idx);
+
+    return _arrow_status;
+}
+
+std::shared_ptr<arrow::Field>
+proto_to_arrow_repeated::field(const std::string& name) {
+    std::shared_ptr<arrow::DataType> arrow_type = arrow::list(arrow::int32());
+    return arrow::field(name, arrow_type);
+};
+
+std::shared_ptr<arrow::ArrayBuilder> proto_to_arrow_repeated::builder() {
+    return _builder;
+};
+
+arrow::Status proto_to_arrow_repeated::finish_batch() {
+    std::cerr << "finish_batch with " << _builder->length() << " items\n";
+
+    if (!_arrow_status.ok()) {
+        return _arrow_status;
+    }
+    auto builder_result = _builder->Finish();
+    _arrow_status = builder_result.status();
+    std::shared_ptr<arrow::Array> array;
+    if (!_arrow_status.ok()) {
+        return _arrow_status;
+    }
+
+    // Safe because we validated the status after calling `Finish`
+    array = std::move(builder_result).ValueUnsafe();
+    std::cerr << "adding array with " << array->length()
+              << " elements to _values\n";
+    _values.push_back(array);
+    return _arrow_status;
+}
+} // namespace datalake::detail

--- a/src/v/datalake/proto_to_arrow_repeated.h
+++ b/src/v/datalake/proto_to_arrow_repeated.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+#pragma once
+
+#include "datalake/proto_to_arrow_interface.h"
+
+#include <arrow/array/builder_base.h>
+#include <arrow/array/builder_nested.h>
+#include <arrow/status.h>
+#include <google/protobuf/descriptor.h>
+
+#include <memory>
+
+namespace datalake::detail {
+
+class proto_to_arrow_repeated : public proto_to_arrow_interface {
+public:
+    proto_to_arrow_repeated(const google::protobuf::FieldDescriptor*);
+    arrow::Status
+    add_child_value(const google::protobuf::Message*, int) override;
+
+    std::shared_ptr<arrow::Field> field(const std::string&) override;
+
+    std::shared_ptr<arrow::ArrayBuilder> builder() override;
+
+    arrow::Status finish_batch() override;
+
+private:
+    std::shared_ptr<arrow::ListBuilder> _builder;
+    std::unique_ptr<proto_to_arrow_interface> _child_converter;
+};
+
+} // namespace datalake::detail

--- a/src/v/datalake/proto_to_arrow_scalar.cc
+++ b/src/v/datalake/proto_to_arrow_scalar.cc
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+#include "datalake/proto_to_arrow_scalar.h"
+
+#include "datalake/logger.h"
+
+#include <arrow/array/array_primitive.h>
+#include <arrow/type.h>
+#include <google/protobuf/message.h>
+
+#include <memory>
+#include <stdexcept>
+
+namespace datalake::detail {
+template<>
+void proto_to_arrow_scalar<arrow::Int32Type>::do_add(
+  const google::protobuf::Message* msg, int field_idx) {
+    auto* desc = msg->GetDescriptor()->field(field_idx);
+    if (!desc) {
+        datalake_log.error("Invalid protobuf field index");
+        _arrow_status = arrow::Status::Invalid("Invalid protobuf field index");
+        return;
+    }
+    _arrow_status = _builder->Append(
+      msg->GetReflection()->GetInt32(*msg, desc));
+}
+
+template<>
+void proto_to_arrow_scalar<arrow::Int64Type>::do_add(
+  const google::protobuf::Message* msg, int field_idx) {
+    auto* desc = msg->GetDescriptor()->field(field_idx);
+    if (!desc) {
+        datalake_log.error("Invalid protobuf field index");
+        _arrow_status = arrow::Status::Invalid("Invalid protobuf field index");
+        return;
+    }
+    _arrow_status = _builder->Append(
+      msg->GetReflection()->GetInt64(*msg, desc));
+}
+
+template<>
+void proto_to_arrow_scalar<arrow::BooleanType>::do_add(
+  const google::protobuf::Message* msg, int field_idx) {
+    auto* desc = msg->GetDescriptor()->field(field_idx);
+    if (!desc) {
+        datalake_log.error("Invalid protobuf field index");
+        _arrow_status = arrow::Status::Invalid("Invalid protobuf field index");
+        return;
+    }
+    _arrow_status = _builder->Append(msg->GetReflection()->GetBool(*msg, desc));
+}
+
+template<>
+void proto_to_arrow_scalar<arrow::FloatType>::do_add(
+  const google::protobuf::Message* msg, int field_idx) {
+    auto* desc = msg->GetDescriptor()->field(field_idx);
+    if (!desc) {
+        datalake_log.error("Invalid protobuf field index");
+        _arrow_status = arrow::Status::Invalid("Invalid protobuf field index");
+        return;
+    }
+    _arrow_status = _builder->Append(
+      msg->GetReflection()->GetFloat(*msg, desc));
+}
+
+template<>
+void proto_to_arrow_scalar<arrow::DoubleType>::do_add(
+  const google::protobuf::Message* msg, int field_idx) {
+    auto* desc = msg->GetDescriptor()->field(field_idx);
+    if (!desc) {
+        datalake_log.error("Invalid protobuf field index");
+        _arrow_status = arrow::Status::Invalid("Invalid protobuf field index");
+        return;
+    }
+    _arrow_status = _builder->Append(
+      msg->GetReflection()->GetDouble(*msg, desc));
+}
+
+template<>
+void proto_to_arrow_scalar<arrow::StringType>::do_add(
+  const google::protobuf::Message* msg, int field_idx) {
+    auto* desc = msg->GetDescriptor()->field(field_idx);
+    if (!desc) {
+        datalake_log.error("Invalid protobuf field index");
+        _arrow_status = arrow::Status::Invalid("Invalid protobuf field index");
+        return;
+    }
+    _arrow_status = _builder->Append(
+      msg->GetReflection()->GetString(*msg, desc));
+}
+
+} // namespace datalake::detail

--- a/src/v/datalake/proto_to_arrow_scalar.cc
+++ b/src/v/datalake/proto_to_arrow_scalar.cc
@@ -28,8 +28,19 @@ void proto_to_arrow_scalar<arrow::Int32Type>::do_add(
         _arrow_status = arrow::Status::Invalid("Invalid protobuf field index");
         return;
     }
-    _arrow_status = _builder->Append(
-      msg->GetReflection()->GetInt32(*msg, desc));
+    if (desc->is_repeated()) {
+        for (int i = 0; i < msg->GetReflection()->FieldSize(*msg, desc); i++) {
+            const auto val = msg->GetReflection()->GetRepeatedInt32(
+              *msg, desc, i);
+            _arrow_status = _builder->Append(val);
+            if (!_arrow_status.ok()) {
+                break;
+            }
+        }
+    } else {
+        _arrow_status = _builder->Append(
+          msg->GetReflection()->GetInt32(*msg, desc));
+    }
 }
 
 template<>
@@ -41,8 +52,19 @@ void proto_to_arrow_scalar<arrow::Int64Type>::do_add(
         _arrow_status = arrow::Status::Invalid("Invalid protobuf field index");
         return;
     }
-    _arrow_status = _builder->Append(
-      msg->GetReflection()->GetInt64(*msg, desc));
+    if (desc->is_repeated()) {
+        for (int i = 0; i < msg->GetReflection()->FieldSize(*msg, desc); i++) {
+            const auto val = msg->GetReflection()->GetRepeatedInt64(
+              *msg, desc, i);
+            _arrow_status = _builder->Append(val);
+            if (!_arrow_status.ok()) {
+                break;
+            }
+        }
+    } else {
+        _arrow_status = _builder->Append(
+          msg->GetReflection()->GetInt64(*msg, desc));
+    }
 }
 
 template<>
@@ -54,7 +76,19 @@ void proto_to_arrow_scalar<arrow::BooleanType>::do_add(
         _arrow_status = arrow::Status::Invalid("Invalid protobuf field index");
         return;
     }
-    _arrow_status = _builder->Append(msg->GetReflection()->GetBool(*msg, desc));
+    if (desc->is_repeated()) {
+        for (int i = 0; i < msg->GetReflection()->FieldSize(*msg, desc); i++) {
+            const auto val = msg->GetReflection()->GetRepeatedBool(
+              *msg, desc, i);
+            _arrow_status = _builder->Append(val);
+            if (!_arrow_status.ok()) {
+                break;
+            }
+        }
+    } else {
+        _arrow_status = _builder->Append(
+          msg->GetReflection()->GetBool(*msg, desc));
+    }
 }
 
 template<>
@@ -66,8 +100,19 @@ void proto_to_arrow_scalar<arrow::FloatType>::do_add(
         _arrow_status = arrow::Status::Invalid("Invalid protobuf field index");
         return;
     }
-    _arrow_status = _builder->Append(
-      msg->GetReflection()->GetFloat(*msg, desc));
+    if (desc->is_repeated()) {
+        for (int i = 0; i < msg->GetReflection()->FieldSize(*msg, desc); i++) {
+            const auto val = msg->GetReflection()->GetRepeatedFloat(
+              *msg, desc, i);
+            _arrow_status = _builder->Append(val);
+            if (!_arrow_status.ok()) {
+                break;
+            }
+        }
+    } else {
+        _arrow_status = _builder->Append(
+          msg->GetReflection()->GetFloat(*msg, desc));
+    }
 }
 
 template<>
@@ -79,8 +124,19 @@ void proto_to_arrow_scalar<arrow::DoubleType>::do_add(
         _arrow_status = arrow::Status::Invalid("Invalid protobuf field index");
         return;
     }
-    _arrow_status = _builder->Append(
-      msg->GetReflection()->GetDouble(*msg, desc));
+    if (desc->is_repeated()) {
+        for (int i = 0; i < msg->GetReflection()->FieldSize(*msg, desc); i++) {
+            const auto val = msg->GetReflection()->GetRepeatedDouble(
+              *msg, desc, i);
+            _arrow_status = _builder->Append(val);
+            if (!_arrow_status.ok()) {
+                break;
+            }
+        }
+    } else {
+        _arrow_status = _builder->Append(
+          msg->GetReflection()->GetDouble(*msg, desc));
+    }
 }
 
 template<>
@@ -92,8 +148,19 @@ void proto_to_arrow_scalar<arrow::StringType>::do_add(
         _arrow_status = arrow::Status::Invalid("Invalid protobuf field index");
         return;
     }
-    _arrow_status = _builder->Append(
-      msg->GetReflection()->GetString(*msg, desc));
+    if (desc->is_repeated()) {
+        for (int i = 0; i < msg->GetReflection()->FieldSize(*msg, desc); i++) {
+            const auto val = msg->GetReflection()->GetRepeatedString(
+              *msg, desc, i);
+            _arrow_status = _builder->Append(val);
+            if (!_arrow_status.ok()) {
+                break;
+            }
+        }
+    } else {
+        _arrow_status = _builder->Append(
+          msg->GetReflection()->GetString(*msg, desc));
+    }
 }
 
 } // namespace datalake::detail

--- a/src/v/datalake/proto_to_arrow_scalar.h
+++ b/src/v/datalake/proto_to_arrow_scalar.h
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+#pragma once
+
+#include "datalake/proto_to_arrow_interface.h"
+
+#include <arrow/api.h>
+
+namespace datalake::detail {
+
+template<typename ArrowType>
+class proto_to_arrow_scalar : public proto_to_arrow_interface {
+    using BuilderType = arrow::TypeTraits<ArrowType>::BuilderType;
+
+public:
+    proto_to_arrow_scalar()
+      : _builder(std::make_shared<BuilderType>()) {}
+
+    arrow::Status add_child_value(
+      const google::protobuf::Message* msg, int field_idx) override {
+        if (!_arrow_status.ok()) {
+            return _arrow_status;
+        }
+        do_add(msg, field_idx);
+        return _arrow_status;
+    }
+
+    arrow::Status finish_batch() override {
+        if (!_arrow_status.ok()) {
+            return _arrow_status;
+        }
+        auto builder_result = _builder->Finish();
+        _arrow_status = builder_result.status();
+        std::shared_ptr<arrow::Array> array;
+        if (!_arrow_status.ok()) {
+            return _arrow_status;
+        }
+
+        // Safe because we validated the status after calling `Finish`
+        array = std::move(builder_result).ValueUnsafe();
+        _values.push_back(array);
+        return _arrow_status;
+    }
+
+    std::shared_ptr<arrow::Field> field(const std::string& name) override {
+        return arrow::field(
+          name, arrow::TypeTraits<ArrowType>::type_singleton());
+    }
+
+    std::shared_ptr<arrow::ArrayBuilder> builder() override { return _builder; }
+
+private:
+    void do_add(const google::protobuf::Message* msg, int field_idx);
+
+    std::shared_ptr<BuilderType> _builder;
+};
+
+} // namespace datalake::detail

--- a/src/v/datalake/proto_to_arrow_struct.cc
+++ b/src/v/datalake/proto_to_arrow_struct.cc
@@ -1,0 +1,167 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+#include "datalake/proto_to_arrow_struct.h"
+
+#include "datalake/logger.h"
+
+#include <arrow/status.h>
+#include <fmt/format.h>
+#include <google/protobuf/descriptor.h>
+#include <google/protobuf/message.h>
+
+arrow::Status datalake::detail::proto_to_arrow_struct::finish_batch() {
+    if (!_arrow_status.ok()) {
+        return _arrow_status;
+    }
+    arrow::Result<std::shared_ptr<arrow::Array>> builder_result
+      = _builder->Finish();
+
+    _arrow_status = builder_result.status();
+    if (!_arrow_status.ok()) {
+        return _arrow_status;
+    }
+
+    // Safe because we validated the status after calling `Finish`
+    _values.push_back(std::move(builder_result).ValueUnsafe());
+
+    return _arrow_status;
+}
+arrow::Status datalake::detail::proto_to_arrow_struct::add_struct_message(
+  const google::protobuf::Message* msg) {
+    if (!_arrow_status.ok()) {
+        return _arrow_status;
+    }
+    for (size_t child_idx = 0; child_idx < _child_converters.size();
+         child_idx++) {
+        _arrow_status = _child_converters[child_idx]->add_child_value(
+          msg, static_cast<int>(child_idx));
+        if (!_arrow_status.ok()) {
+            return _arrow_status;
+        }
+    }
+    _arrow_status = _builder->Append();
+
+    return _arrow_status;
+}
+arrow::Status datalake::detail::proto_to_arrow_struct::add_child_value(
+  const google::protobuf::Message* msg, int field_idx) {
+    if (!_arrow_status.ok()) {
+        return _arrow_status;
+    }
+    auto* desc = msg->GetDescriptor()->field(field_idx);
+    if (!desc) {
+        datalake_log.error("Invalid protobuf field index");
+        _arrow_status = arrow::Status::Invalid("Invalid protobuf field index");
+        return _arrow_status;
+    }
+    auto child_message = &msg->GetReflection()->GetMessage(*msg, desc);
+    return add_struct_message(child_message);
+}
+datalake::detail::proto_to_arrow_struct::proto_to_arrow_struct(
+  const google::protobuf::Descriptor* message_descriptor) {
+    using namespace detail;
+    namespace pb = google::protobuf;
+
+    // Set up child arrays
+    _child_converters.reserve(message_descriptor->field_count());
+    for (int field_idx = 0; field_idx < message_descriptor->field_count();
+         field_idx++) {
+        auto* desc = message_descriptor->field(field_idx);
+        if (!desc) {
+            datalake_log.error("Invalid protobuf field index");
+            _arrow_status = arrow::Status::Invalid(
+              "Invalid protobuf field index");
+            throw datalake::initialization_error(
+              "Invalid protobuf field index");
+        }
+        switch (desc->cpp_type()) {
+        case pb::FieldDescriptor::CPPTYPE_INT32:
+            _child_converters.push_back(
+              std::make_unique<proto_to_arrow_scalar<arrow::Int32Type>>());
+            break;
+        case pb::FieldDescriptor::CPPTYPE_INT64:
+            _child_converters.push_back(
+              std::make_unique<proto_to_arrow_scalar<arrow::Int64Type>>());
+            break;
+        case pb::FieldDescriptor::CPPTYPE_BOOL:
+            _child_converters.push_back(
+              std::make_unique<proto_to_arrow_scalar<arrow::BooleanType>>());
+            break;
+        case pb::FieldDescriptor::CPPTYPE_FLOAT:
+            _child_converters.push_back(
+              std::make_unique<proto_to_arrow_scalar<arrow::FloatType>>());
+            break;
+        case pb::FieldDescriptor::CPPTYPE_DOUBLE:
+            _child_converters.push_back(
+              std::make_unique<proto_to_arrow_scalar<arrow::DoubleType>>());
+            break;
+        case pb::FieldDescriptor::CPPTYPE_STRING:
+            _child_converters.push_back(
+              std::make_unique<proto_to_arrow_scalar<arrow::StringType>>());
+            break;
+        case pb::FieldDescriptor::CPPTYPE_MESSAGE: {
+            auto field_message_descriptor = desc->message_type();
+            if (field_message_descriptor == nullptr) {
+                _arrow_status = arrow::Status::Invalid(
+                  "Invalid protobuf field index");
+                throw datalake::initialization_error(fmt::format(
+                  "Can't find schema for nested type : {}",
+                  desc->cpp_type_name()));
+            }
+            _child_converters.push_back(std::make_unique<proto_to_arrow_struct>(
+              field_message_descriptor));
+        } break;
+        case pb::FieldDescriptor::CPPTYPE_ENUM:   // TODO
+        case pb::FieldDescriptor::CPPTYPE_UINT32: // not supported by Iceberg
+        case pb::FieldDescriptor::CPPTYPE_UINT64: // not supported by Iceberg
+            throw datalake::initialization_error(
+              fmt::format("Unknown type: {}", desc->cpp_type_name()));
+        }
+    }
+    // Make Arrow data types
+
+    // This could be combined into a single loop with the one above, splitting
+    // them out for readability.
+    _fields.reserve(message_descriptor->field_count());
+    for (int field_idx = 0; field_idx < message_descriptor->field_count();
+         field_idx++) {
+        auto* field_desc = message_descriptor->field(field_idx);
+        if (!field_desc) {
+            datalake_log.error("Invalid protobuf field index");
+            _arrow_status = arrow::Status::Invalid(
+              "Invalid protobuf field index");
+            throw datalake::initialization_error(
+              "Invalid protobuf field index");
+        }
+        _fields.push_back(
+          _child_converters[field_idx]->field(field_desc->name()));
+    }
+    _arrow_data_type = arrow::struct_(_fields);
+
+    // Make builder
+    std::vector<std::shared_ptr<arrow::ArrayBuilder>> child_builders;
+    child_builders.reserve(_child_converters.size());
+    for (auto& child : _child_converters) {
+        child_builders.push_back(child->builder());
+    }
+    _builder = std::make_shared<arrow::StructBuilder>(
+      _arrow_data_type, arrow::default_memory_pool(), child_builders);
+}
+std::shared_ptr<arrow::ArrayBuilder>
+datalake::detail::proto_to_arrow_struct::builder() {
+    return _builder;
+}
+std::shared_ptr<arrow::Field>
+datalake::detail::proto_to_arrow_struct::field(const std::string& name) {
+    return arrow::field(name, _arrow_data_type);
+}
+arrow::FieldVector datalake::detail::proto_to_arrow_struct::get_field_vector() {
+    return _fields;
+}

--- a/src/v/datalake/proto_to_arrow_struct.h
+++ b/src/v/datalake/proto_to_arrow_struct.h
@@ -11,13 +11,16 @@
 
 #include "datalake/errors.h"
 #include "datalake/proto_to_arrow_interface.h"
-#include "datalake/proto_to_arrow_scalar.h"
+
+#include <google/protobuf/descriptor.h>
+#include <google/protobuf/type.pb.h>
 
 #include <memory>
 #include <stdexcept>
 
 namespace google::protobuf {
 class Descriptor;
+class FieldDescriptor;
 }
 
 namespace datalake::detail {
@@ -49,5 +52,8 @@ private:
     std::shared_ptr<arrow::StructBuilder> _builder;
     arrow::FieldVector _fields;
 };
+
+std::unique_ptr<proto_to_arrow_interface> make_converter(
+  const google::protobuf::FieldDescriptor* desc, bool ignore_repeated = false);
 
 } // namespace datalake::detail

--- a/src/v/datalake/proto_to_arrow_struct.h
+++ b/src/v/datalake/proto_to_arrow_struct.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+#pragma once
+
+#include "datalake/errors.h"
+#include "datalake/proto_to_arrow_interface.h"
+#include "datalake/proto_to_arrow_scalar.h"
+
+#include <memory>
+#include <stdexcept>
+
+namespace google::protobuf {
+class Descriptor;
+}
+
+namespace datalake::detail {
+
+class proto_to_arrow_struct : public proto_to_arrow_interface {
+public:
+    explicit proto_to_arrow_struct(
+      const google::protobuf::Descriptor* message_descriptor);
+
+    // Because this is a struct builder, we expect the child referred to by
+    // field_idx to be a struct itself.
+    arrow::Status add_child_value(
+      const google::protobuf::Message* msg, int field_idx) override;
+
+    // Adds the message pointed to by msg. Unlike add_child_value, this adds
+    // the message itself, and not a child of the message.
+    arrow::Status add_struct_message(const google::protobuf::Message* msg);
+
+    arrow::Status finish_batch() override;
+
+    std::shared_ptr<arrow::Field> field(const std::string& name) override;
+    std::shared_ptr<arrow::ArrayBuilder> builder() override;
+
+    arrow::FieldVector get_field_vector();
+
+private:
+    std::vector<std::unique_ptr<proto_to_arrow_interface>> _child_converters;
+    std::shared_ptr<arrow::DataType> _arrow_data_type;
+    std::shared_ptr<arrow::StructBuilder> _builder;
+    arrow::FieldVector _fields;
+};
+
+} // namespace datalake::detail

--- a/src/v/datalake/protobuf_to_arrow_converter.cc
+++ b/src/v/datalake/protobuf_to_arrow_converter.cc
@@ -1,0 +1,167 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+#include "datalake/protobuf_to_arrow_converter.h"
+
+#include "datalake/errors.h"
+#include "datalake/logger.h"
+#include "datalake/proto_to_arrow_struct.h"
+
+#include <arrow/api.h>
+#include <arrow/array/builder_base.h>
+#include <arrow/array/builder_nested.h>
+#include <arrow/chunked_array.h>
+#include <arrow/io/api.h>
+#include <arrow/result.h>
+#include <arrow/status.h>
+#include <arrow/type.h>
+#include <arrow/type_fwd.h>
+#include <arrow/type_traits.h>
+#include <google/protobuf/arena.h>
+#include <google/protobuf/compiler/parser.h>
+#include <google/protobuf/descriptor.h>
+#include <google/protobuf/dynamic_message.h>
+#include <google/protobuf/io/tokenizer.h>
+#include <google/protobuf/io/zero_copy_stream_impl_lite.h>
+#include <google/protobuf/message.h>
+#include <google/protobuf/stubs/common.h>
+#include <google/protobuf/unknown_field_set.h>
+
+#include <memory>
+#include <stdexcept>
+
+namespace datalake {
+
+proto_to_arrow_converter::proto_to_arrow_converter(const ss::sstring& schema) {
+    // TODO: Most of the complex logic should go in a factory method.
+    initialize_protobuf_schema(schema);
+    if (!initialize_struct_converter()) {
+        throw initialization_error("Could not initialize arrow arrays");
+    }
+}
+arrow_converter_status
+proto_to_arrow_converter::add_message(const ss::sstring& serialized_message) {
+    std::unique_ptr<google::protobuf::Message> message = parse_message(
+      serialized_message);
+    if (message == nullptr) {
+        return arrow_converter_status::parse_error;
+    }
+
+    if (!_struct_converter->add_struct_message(message.get()).ok()) {
+        return arrow_converter_status::internal_error;
+    }
+    return arrow_converter_status::ok;
+}
+arrow_converter_status proto_to_arrow_converter::finish_batch() {
+    if (!_struct_converter->finish_batch().ok()) {
+        return arrow_converter_status::internal_error;
+    }
+    return arrow_converter_status::ok;
+}
+std::shared_ptr<arrow::Table> proto_to_arrow_converter::build_table() {
+    auto table_result = arrow::Table::FromChunkedStructArray(
+      _struct_converter->finish());
+    if (table_result.ok()) {
+        return table_result.ValueUnsafe();
+    } else {
+        return nullptr;
+    }
+}
+
+std::shared_ptr<arrow::Schema> proto_to_arrow_converter::build_schema() {
+    return arrow::schema(_struct_converter->get_field_vector());
+}
+
+void proto_to_arrow_converter::initialize_protobuf_schema(
+  const ss::sstring& schema) {
+    google::protobuf::io::ArrayInputStream proto_input_stream(
+      schema.c_str(), static_cast<int>(schema.size()));
+    google::protobuf::io::Tokenizer tokenizer(
+      &proto_input_stream, &error_collector);
+
+    google::protobuf::compiler::Parser parser;
+    parser.RecordErrorsTo(&error_collector);
+    if (!parser.Parse(&tokenizer, &_file_descriptor_proto)) {
+        throw initialization_error("Could not parse protobuf schema");
+    }
+
+    if (!_file_descriptor_proto.has_name()) {
+        _file_descriptor_proto.set_name("DefaultMessageName");
+    }
+
+    _file_desc = _protobuf_descriptor_pool.BuildFile(_file_descriptor_proto);
+    if (_file_desc == nullptr) {
+        throw initialization_error("Could not build descriptor pool");
+    }
+}
+bool proto_to_arrow_converter::initialize_struct_converter() {
+    const google::protobuf::Descriptor* message_desc = message_descriptor();
+    if (message_desc == nullptr) {
+        return false;
+    }
+
+    _struct_converter = std::make_unique<detail::proto_to_arrow_struct>(
+      message_desc);
+
+    return true;
+}
+std::unique_ptr<google::protobuf::Message>
+proto_to_arrow_converter::parse_message(const ss::sstring& message) {
+    // Get the message descriptor
+    const google::protobuf::Descriptor* message_desc = message_descriptor();
+    if (message_desc == nullptr) {
+        return nullptr;
+    }
+
+    const google::protobuf::Message* prototype_msg = _factory.GetPrototype(
+      message_desc);
+    if (prototype_msg == nullptr) {
+        return nullptr;
+    }
+
+    std::unique_ptr<google::protobuf::Message> mutable_msg
+      = std::unique_ptr<google::protobuf::Message>(prototype_msg->New());
+    if (mutable_msg == nullptr) {
+        return nullptr;
+    }
+
+    if (!mutable_msg->ParseFromString(message)) {
+        datalake_log.debug(
+          "Failed to parse protobuf message. Protobuf error string: \"{}\"",
+          mutable_msg->InitializationErrorString());
+        return nullptr;
+    }
+    return mutable_msg;
+}
+
+const google::protobuf::Descriptor*
+datalake::proto_to_arrow_converter::message_descriptor() {
+    // A Protobuf schema can contain multiple message types.
+    // This code assumes the first message type defined in the file
+    // is the main one. (In Kafka, this is considered the common case and
+    // optimized)
+    // TODO: parse message descriptor path from message
+    // https://github.com/confluentinc/confluent-kafka-go/blob/b6a3254310f6d9707f283f0b53ef4d3e1ff48e3b/schemaregistry/serde/protobuf/protobuf.go#L437-L456
+    int message_type_count = _file_desc->message_type_count();
+    if (message_type_count == 0) {
+        return nullptr;
+    }
+    return _file_desc->message_type(0);
+}
+void error_collector::AddError(
+  int line, int column, const std::string& message) {
+    // Warning level because this is an error in the input, not Redpanda
+    // itself.
+    datalake_log.warn("Protobuf Error {}:{} {}", line, column, message);
+}
+void error_collector::AddWarning(
+  int line, int column, const std::string& message) {
+    datalake_log.warn("Protobuf Warning {}:{} {}", line, column, message);
+}
+} // namespace datalake

--- a/src/v/datalake/protobuf_to_arrow_converter.h
+++ b/src/v/datalake/protobuf_to_arrow_converter.h
@@ -53,6 +53,7 @@ private:
     FRIEND_TEST(ArrowWriter, SimpleMessageTest);
     FRIEND_TEST(ArrowWriter, NestedMessageTest);
     FRIEND_TEST(ArrowWriter, InvalidMessagetest);
+    FRIEND_TEST(ArrowWriter, RepeatedFeildTest);
 
     void initialize_protobuf_schema(const ss::sstring& schema);
 

--- a/src/v/datalake/protobuf_to_arrow_converter.h
+++ b/src/v/datalake/protobuf_to_arrow_converter.h
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+#pragma once
+#include "datalake/errors.h"
+#include "datalake/logger.h"
+#include "datalake/proto_to_arrow_interface.h"
+#include "datalake/proto_to_arrow_scalar.h"
+#include "datalake/proto_to_arrow_struct.h"
+
+#include <google/protobuf/compiler/parser.h>
+#include <google/protobuf/descriptor.h>
+#include <google/protobuf/dynamic_message.h>
+#include <google/protobuf/io/tokenizer.h>
+
+#include <memory>
+#include <stdexcept>
+
+namespace datalake {
+
+struct error_collector : ::google::protobuf::io::ErrorCollector {
+    void AddError(int line, int column, const std::string& message) override;
+    void AddWarning(int line, int column, const std::string& message) override;
+};
+
+/** Top-level interface for parsing Protobuf messages to an Arrow table
+
+This class deserializes protobuf messages and passes the deserialized messages
+to an instance of proto_to_arrow_struct to recursively parse the structured
+message.
+*/
+class proto_to_arrow_converter {
+public:
+    explicit proto_to_arrow_converter(const ss::sstring& schema);
+
+    [[nodiscard]] arrow_converter_status
+    add_message(const ss::sstring& serialized_message);
+
+    [[nodiscard]] arrow_converter_status finish_batch();
+
+    std::shared_ptr<arrow::Table> build_table();
+
+    std::shared_ptr<arrow::Schema> build_schema();
+
+private:
+    FRIEND_TEST(ArrowWriter, EmptyMessageTest);
+    FRIEND_TEST(ArrowWriter, SimpleMessageTest);
+    FRIEND_TEST(ArrowWriter, NestedMessageTest);
+    FRIEND_TEST(ArrowWriter, InvalidMessagetest);
+
+    void initialize_protobuf_schema(const ss::sstring& schema);
+
+    bool initialize_struct_converter();
+
+    /// Parse the message to a protobuf message.
+    /// Return nullptr on error.
+    // TODO: Add a version of this method that takes an iobuf
+    // and creates a `google::protobuf::io::ZeroCopyInputStream`.
+    // We can then call ParseFromBoundedZeroCopyStream
+    std::unique_ptr<google::protobuf::Message>
+    parse_message(const ss::sstring& message);
+    const google::protobuf::Descriptor* message_descriptor();
+
+private:
+    google::protobuf::DescriptorPool _protobuf_descriptor_pool;
+    google::protobuf::FileDescriptorProto _file_descriptor_proto;
+    google::protobuf::DynamicMessageFactory _factory;
+    const google::protobuf::FileDescriptor* _file_desc{};
+
+    std::unique_ptr<detail::proto_to_arrow_struct> _struct_converter;
+    error_collector error_collector;
+};
+
+} // namespace datalake

--- a/src/v/datalake/tests/CMakeLists.txt
+++ b/src/v/datalake/tests/CMakeLists.txt
@@ -1,0 +1,13 @@
+rp_test(
+    UNIT_TEST
+    GTEST
+    BINARY_NAME gtest_proto_to_arrow
+    SOURCES
+      proto_to_arrow_gtest.cc
+    LIBRARIES
+      v::gtest_main
+      v::datalake
+    LABELS datalake
+    ARGS "-- -c 1"
+  )
+  

--- a/src/v/datalake/tests/proto_to_arrow_gtest.cc
+++ b/src/v/datalake/tests/proto_to_arrow_gtest.cc
@@ -1,0 +1,186 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+#include "datalake/errors.h"
+#include "datalake/protobuf_to_arrow_converter.h"
+#include "datalake/tests/proto_to_arrow_test_utils.h"
+#include "test_utils/test.h"
+
+#include <google/protobuf/descriptor.h>
+#include <google/protobuf/message.h>
+#include <gtest/gtest.h>
+
+#include <stdexcept>
+#include <string>
+
+namespace datalake {
+TEST(ArrowWriter, InvalidMessagetest) {
+    using namespace datalake;
+    test_data test_data;
+    std::string schema = test_data.empty_schema;
+
+    proto_to_arrow_converter converter(schema);
+
+    std::string serialized_message{"This is not a Protobuf message!"};
+
+    auto parsed_message = converter.parse_message(serialized_message);
+    EXPECT_EQ(parsed_message, nullptr);
+}
+
+TEST(ArrowWriter, EmptyMessageTest) {
+    using namespace datalake;
+    test_data test_data;
+    std::string schema = test_data.empty_schema;
+
+    proto_to_arrow_converter converter(schema);
+
+    std::string serialized_message = generate_empty_message();
+
+    auto parsed_message = converter.parse_message(serialized_message);
+    EXPECT_NE(parsed_message, nullptr);
+    EXPECT_EQ(parsed_message->GetTypeName(), "datalake.proto.empty_message");
+}
+
+TEST(ArrowWriter, SimpleMessageTest) {
+    using namespace datalake;
+    std::string serialized_message = generate_simple_message(
+      "Hello world", 12345);
+
+    test_data test_data;
+    proto_to_arrow_converter converter(test_data.simple_schema);
+    auto parsed_message = converter.parse_message(serialized_message);
+    EXPECT_NE(parsed_message, nullptr);
+    EXPECT_EQ(parsed_message->GetTypeName(), "datalake.proto.simple_message");
+
+    EXPECT_EQ(
+      arrow_converter_status::ok, converter.add_message(serialized_message));
+    {
+        EXPECT_EQ(
+          arrow_converter_status::ok,
+          converter.add_message(generate_simple_message("I", 1)));
+        EXPECT_EQ(
+          arrow_converter_status::ok,
+          converter.add_message(generate_simple_message("II", 2)));
+        EXPECT_EQ(
+          arrow_converter_status::ok,
+          converter.add_message(generate_simple_message("III", 3)));
+        EXPECT_EQ(
+          arrow_converter_status::ok,
+          converter.add_message(generate_simple_message("IV", 4)));
+        EXPECT_EQ(
+          arrow_converter_status::ok,
+          converter.add_message(generate_simple_message("V", 5)));
+    }
+    EXPECT_EQ(arrow_converter_status::ok, converter.finish_batch());
+
+    auto schema = converter.build_schema();
+    auto table = converter.build_table();
+    EXPECT_EQ(
+      schema->field_names(),
+      std::vector<std::string>(
+        {"label",
+         "number",
+         "big_number",
+         "float_number",
+         "double_number",
+         "true_or_false"}));
+    std::vector<std::string> table_field_names;
+    for (const auto& field : table->fields()) {
+        table_field_names.push_back(field->name());
+    }
+    EXPECT_EQ(table_field_names, schema->field_names());
+    std::vector<std::string> expected{
+      "Hello world", "I", "II", "III", "IV", "V"};
+    for (int i = 0; i < expected.size(); i++) {
+        EXPECT_EQ(
+          table->GetColumnByName("label")->GetScalar(i)->get()->ToString(),
+          expected[i]);
+    }
+
+    expected = {"12345", "1", "2", "3", "4", "5"};
+    for (int i = 0; i < expected.size(); i++) {
+        EXPECT_EQ(
+          table->GetColumnByName("number")->GetScalar(i)->get()->ToString(),
+          expected[i]);
+    }
+    EXPECT_EQ(
+      table->ToString(),
+      "label: string\nnumber: int32\nbig_number: int64\nfloat_number: "
+      "float\ndouble_number: double\ntrue_or_false: bool\n----\nlabel:\n  [\n  "
+      "  [\n      \"Hello world\",\n      \"I\",\n      \"II\",\n      "
+      "\"III\",\n      \"IV\",\n      \"V\"\n    ]\n  ]\nnumber:\n  [\n    [\n "
+      "     12345,\n      1,\n      2,\n      3,\n      4,\n      5\n    ]\n  "
+      "]\nbig_number:\n  [\n    [\n      123450,\n      10,\n      20,\n      "
+      "30,\n      40,\n      50\n    ]\n  ]\nfloat_number:\n  [\n    [\n      "
+      "1234.5,\n      0.1,\n      0.2,\n      0.3,\n      0.4,\n      0.5\n    "
+      "]\n  ]\ndouble_number:\n  [\n    [\n      123.45,\n      0.01,\n      "
+      "0.02,\n      0.03,\n      0.04,\n      0.05\n    ]\n  "
+      "]\ntrue_or_false:\n  [\n    [\n      false,\n      false,\n      "
+      "true,\n      false,\n      true,\n      false\n    ]\n  ]\n");
+}
+
+TEST(ArrowWriter, NestedMessageTest) {
+    using namespace datalake;
+    std::string serialized_message = generate_nested_message(
+      "Hello world", 12345);
+
+    test_data test_data;
+    proto_to_arrow_converter converter(test_data.nested_schema);
+    auto parsed_message = converter.parse_message(serialized_message);
+    EXPECT_NE(parsed_message, nullptr);
+    EXPECT_EQ(parsed_message->GetTypeName(), "datalake.proto.nested_message");
+
+    EXPECT_EQ(
+      arrow_converter_status::ok, converter.add_message(serialized_message));
+    {
+        EXPECT_EQ(
+          arrow_converter_status::ok,
+          converter.add_message(generate_nested_message("I", 1)));
+        EXPECT_EQ(
+          arrow_converter_status::ok,
+          converter.add_message(generate_nested_message("II", 2)));
+        EXPECT_EQ(
+          arrow_converter_status::ok,
+          converter.add_message(generate_nested_message("III", 3)));
+        EXPECT_EQ(
+          arrow_converter_status::ok,
+          converter.add_message(generate_nested_message("IV", 4)));
+        EXPECT_EQ(
+          arrow_converter_status::ok,
+          converter.add_message(generate_nested_message("V", 5)));
+    }
+    EXPECT_EQ(arrow_converter_status::ok, converter.finish_batch());
+
+    auto schema = converter.build_schema();
+    auto table = converter.build_table();
+
+    EXPECT_EQ(
+      schema->field_names(),
+      std::vector<std::string>({"label", "number", "inner_message"}));
+    std::vector<std::string> table_field_names;
+    for (const auto& field : table->fields()) {
+        table_field_names.push_back(field->name());
+    }
+    EXPECT_EQ(table_field_names, schema->field_names());
+    EXPECT_EQ(
+      table->ToString(),
+      "label: string\nnumber: int32\ninner_message: struct<inner_label: "
+      "string, inner_number: int32>\n  child 0, inner_label: string\n  child "
+      "1, inner_number: int32\n----\nlabel:\n  [\n    [\n      \"Hello "
+      "world\",\n      \"I\",\n      \"II\",\n      \"III\",\n      \"IV\",\n  "
+      "    \"V\"\n    ]\n  ]\nnumber:\n  [\n    [\n      12345,\n      1,\n    "
+      "  2,\n      3,\n      4,\n      5\n    ]\n  ]\ninner_message:\n  [\n    "
+      "-- is_valid: all not null\n    -- child 0 type: string\n      [\n       "
+      " \"inner: Hello world\",\n        \"inner: I\",\n        \"inner: "
+      "II\",\n        \"inner: III\",\n        \"inner: IV\",\n        "
+      "\"inner: V\"\n      ]\n    -- child 1 type: int32\n      [\n        "
+      "-12345,\n        -1,\n        -2,\n        -3,\n        -4,\n        "
+      "-5\n      ]\n  ]\n");
+}
+} // namespace datalake

--- a/src/v/datalake/tests/proto_to_arrow_test_utils.h
+++ b/src/v/datalake/tests/proto_to_arrow_test_utils.h
@@ -1,0 +1,373 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+#pragma once
+#include "model/record.h"
+#include "random/generators.h"
+
+#include <seastar/core/circular_buffer.hh>
+
+#include <compression/compression.h>
+#include <google/protobuf/message.h>
+
+#include <cstdlib>
+#include <sstream>
+#include <string>
+
+namespace datalake {
+// This is here for now to split up the stack of commits into separate PRs
+struct schema_info {
+    std::string schema;
+};
+} // namespace datalake
+
+struct test_data {
+    std::string empty_schema = (R"schema(
+      syntax = "proto2";
+package datalake.proto;
+
+message empty_message {}
+    )schema");
+
+    std::string simple_schema = (R"schema(
+      syntax = "proto2";
+package datalake.proto;
+
+message simple_message {
+  optional string label = 1;
+  optional int32 number = 3;
+  optional int64 big_number = 4;
+  optional float float_number = 5;
+  optional double double_number = 6;
+  optional bool true_or_false = 7;
+}
+    )schema");
+
+    std::string nested_schema = (R"schema(
+syntax = "proto2";
+package datalake.proto;
+
+message nested_message {
+  optional string label = 1;
+  optional int32 number = 2;
+  optional inner_message_t inner_message = 3;
+}
+
+message inner_message_t {
+  optional string inner_label = 1;
+  optional int32 inner_number = 2;
+}
+
+)schema");
+
+    std::string combined_schema = (R"schema(
+syntax = "proto2";
+package datalake.proto;
+
+message empty_message {}
+
+message simple_message {
+  optional string label = 1;
+  optional int32 number = 3;
+  optional int64 big_number = 4;
+  optional float float_number = 5;
+  optional double double_number = 6;
+  optional bool true_or_false = 7;
+}
+
+message inner_message_t {
+  optional string inner_label = 1;
+  optional int32 inner_number = 2;
+}
+
+message nested_message {
+  optional string label = 1;
+  optional int32 number = 2;
+  optional inner_message_t inner_message = 3;
+}
+)schema");
+
+    std::string test_message_name = "simple_message";
+};
+
+// TODO: Make this a fixture?
+struct test_message_builder {
+    test_message_builder(test_data data)
+      : _proto_input_stream{data.combined_schema.c_str(), int(data.combined_schema.size())}
+      , _tokenizer{&_proto_input_stream, nullptr} {
+        if (!_parser.Parse(&_tokenizer, &_file_descriptor_proto)) {
+            exit(-1);
+        }
+
+        if (!_file_descriptor_proto.has_name()) {
+            _file_descriptor_proto.set_name("proto_file");
+        }
+
+        // Build a descriptor pool
+        _file_desc = _pool.BuildFile(_file_descriptor_proto);
+        assert(_file_desc != nullptr);
+    }
+
+    google::protobuf::Message* generate_unserialized_message_generic(
+      const std::string& message_type,
+      const std::function<void(google::protobuf::Message*)>& populate_message) {
+        // Get the message descriptor
+        const google::protobuf::Descriptor* message_desc
+          = _file_desc->FindMessageTypeByName(message_type);
+        assert(message_desc != nullptr);
+
+        // Parse the actual message
+        const google::protobuf::Message* prototype_msg = _factory.GetPrototype(
+          message_desc);
+        assert(prototype_msg != nullptr);
+
+        google::protobuf::Message* mutable_msg = prototype_msg->New();
+        assert(mutable_msg != nullptr);
+        populate_message(mutable_msg);
+
+        return mutable_msg;
+    }
+
+    std::string generate_message_generic(
+      const std::string& message_type,
+      const std::function<void(google::protobuf::Message*)>& populate_message) {
+        auto msg = generate_unserialized_message_generic(
+          message_type, populate_message);
+        std::string ret = msg->SerializeAsString();
+        delete msg;
+        return ret;
+    }
+
+    google::protobuf::FileDescriptorProto _file_descriptor_proto;
+    google::protobuf::compiler::Parser _parser;
+    google::protobuf::io::ArrayInputStream _proto_input_stream;
+    google::protobuf::io::Tokenizer _tokenizer;
+    google::protobuf::DescriptorPool _pool;
+    const google::protobuf::FileDescriptor* _file_desc;
+    google::protobuf::DynamicMessageFactory _factory;
+};
+
+inline std::string generate_empty_message() {
+    test_data test_data;
+    test_message_builder builder(test_data);
+    return builder.generate_message_generic(
+      "empty_message", [](google::protobuf::Message* message) {});
+}
+
+inline std::string
+generate_simple_message(const std::string& label, int32_t number) {
+    test_data test_data;
+    test_message_builder builder(test_data);
+    return builder.generate_message_generic(
+      "simple_message", [&](google::protobuf::Message* message) {
+          auto reflection = message->GetReflection();
+          // Have to use field indices here because
+          // message->GetReflections()->ListFields() only returns fields
+          // that are actually present in the message;
+          for (int field_idx = 0;
+               field_idx < message->GetDescriptor()->field_count();
+               field_idx++) {
+              auto field_desc = message->GetDescriptor()->field(field_idx);
+              if (field_desc->name() == "label") {
+                  reflection->SetString(message, field_desc, label);
+              } else if (field_desc->name() == "number") {
+                  reflection->SetInt32(message, field_desc, number);
+              } else if (field_desc->name() == "big_number") {
+                  reflection->SetInt64(message, field_desc, 10 * number);
+              } else if (field_desc->name() == "float_number") {
+                  reflection->SetFloat(message, field_desc, number / 10.0);
+              } else if (field_desc->name() == "double_number") {
+                  reflection->SetDouble(message, field_desc, number / 100.0);
+              } else if (field_desc->name() == "true_or_false") {
+                  reflection->SetBool(message, field_desc, number % 2 == 0);
+              }
+          }
+      });
+}
+
+inline google::protobuf::Message* generate_inner_message(
+  test_message_builder& builder, const std::string& label, int32_t number) {
+    auto ret = builder.generate_unserialized_message_generic(
+      "inner_message_t", [&](google::protobuf::Message* message) {
+          auto reflection = message->GetReflection();
+          // Have to use field indices here because
+          // message->GetReflections()->ListFields() only returns fields
+          // that are actually present in the message;
+          for (int field_idx = 0;
+               field_idx < message->GetDescriptor()->field_count();
+               field_idx++) {
+              auto field_desc = message->GetDescriptor()->field(field_idx);
+              if (field_desc->name() == "inner_label") {
+                  reflection->SetString(message, field_desc, label);
+              } else if (field_desc->name() == "inner_number") {
+                  reflection->SetInt32(message, field_desc, number);
+              }
+          }
+      });
+
+    return ret;
+}
+
+inline std::string
+generate_nested_message(const std::string& label, int32_t number) {
+    test_data test_data;
+    test_message_builder builder(test_data);
+    auto inner = generate_inner_message(builder, "inner: " + label, -number);
+
+    return builder.generate_message_generic(
+      "nested_message", [&](google::protobuf::Message* message) {
+          auto reflection = message->GetReflection();
+          // Have to use field indices here because
+          // message->GetReflections()->ListFields() only returns fields
+          // that are actually present in the message;
+
+          for (int field_idx = 0;
+               field_idx < message->GetDescriptor()->field_count();
+               field_idx++) {
+              auto field_desc = message->GetDescriptor()->field(field_idx);
+              if (field_desc->name() == "label") {
+                  reflection->SetString(message, field_desc, label);
+              } else if (field_desc->name() == "number") {
+                  reflection->SetInt32(message, field_desc, number);
+              } else if (field_desc->name() == "inner_message") {
+                  reflection->SetAllocatedMessage(message, inner, field_desc);
+              }
+          }
+      });
+}
+
+inline datalake::schema_info get_test_schema() {
+    test_data data;
+    return {
+      .schema = data.nested_schema,
+    };
+}
+
+struct protobuf_random_batches_generator {
+    ss::circular_buffer<model::record_batch>
+    operator()(std::optional<model::timestamp> base_ts = std::nullopt) {
+        int count = random_generators::get_int(1, 10);
+        bool allow_compression = true;
+        model::offset offset(0);
+        model::timestamp ts = base_ts.value_or(model::timestamp::now());
+
+        ss::circular_buffer<model::record_batch> ret;
+        ret.reserve(count);
+        for (int i = 0; i < count; i++) {
+            // TODO: See todo comment in make_random_batches
+            auto b = make_protobuf_batch(offset, allow_compression, ts);
+            offset = b.last_offset() + model::offset(1);
+            b.set_term(model::term_id(0));
+            ret.push_back(std::move(b));
+        }
+        return ret;
+    }
+
+    // Return a batch of records containing protobuf data using the simple
+    // schema above.
+    model::record_batch make_protobuf_batch(
+      model::offset offset, bool allow_compression, model::timestamp ts) {
+        // Based on make_random_batch, skip the transaction and idempotence
+        // stuff.
+        auto num_records = random_generators::get_int(1, 30);
+        auto max_ts = model::timestamp(ts() + num_records - 1);
+        auto header = model::record_batch_header{
+          .size_bytes = 0, // computed later
+          .base_offset = offset,
+          .type = model::record_batch_type::raft_data,
+          .crc = 0, // we reassign later
+          .attrs = model::record_batch_attributes(
+            random_generators::get_int<int16_t>(0, allow_compression ? 4 : 0)),
+          .last_offset_delta = num_records - 1,
+          .first_timestamp = ts,
+          .max_timestamp = max_ts,
+          .producer_id = -1,
+          .producer_epoch = -1,
+          .base_sequence = 0,
+          .record_count = num_records};
+
+        auto size = model::packed_record_batch_header_size;
+        model::record_batch::records_type records;
+        auto rs = model::record_batch::uncompressed_records();
+        rs.reserve(num_records);
+        for (int i = 0; i < num_records; i++) {
+            std::stringstream key_stream;
+            key_stream << i;
+
+            std::string value = generate_simple_message(
+              "message # " + key_stream.str(), i);
+            rs.emplace_back(
+              make_record(offset() + i, ts() + i, key_stream.str(), value));
+        }
+
+        if (header.attrs.compression() != model::compression::none) {
+            iobuf body;
+            for (auto& r : rs) {
+                model::append_record_to_buffer(body, r);
+            }
+            rs.clear();
+            records = compression::compressor::compress(
+              body, header.attrs.compression());
+            size += std::get<iobuf>(records).size_bytes();
+        } else {
+            for (auto& r : rs) {
+                size += r.size_bytes();
+                size += vint::vint_size(r.size_bytes());
+            }
+            records = std::move(rs);
+        }
+        header.ctx = model::record_batch_header::context(
+          model::term_id(0), ss::this_shard_id());
+        header.size_bytes = size;
+        auto batch = model::record_batch(header, std::move(records));
+        batch.header().crc = model::crc_record_batch(batch);
+        batch.header().header_crc = model::internal_header_only_crc(
+          batch.header());
+        return batch;
+    }
+
+    model::record make_record(
+      int ts_delta,
+      int offset_delta,
+      std::string key_string,
+      std::string value_string) {
+        iobuf key;
+        iobuf value;
+        key.append(key_string.data(), key_string.size());
+        value.append(value_string.data(), value_string.size());
+        // Headers in the storages tests are just random. We can leave them
+        // empty.
+        std::vector<model::record_header> headers;
+
+        auto size = sizeof(model::record_attributes::type) // attributes
+                    + vint::vint_size(ts_delta)            // timestamp delta
+                    + vint::vint_size(offset_delta)        // offset delta
+                    + vint::vint_size(key.size_bytes())    // size of key-len
+                    + key.size_bytes()                     // size of key
+                    + vint::vint_size(value.size_bytes())  // size of value
+                    + value.size_bytes() // size of value (includes lengths)
+                    + vint::vint_size(headers.size());
+        for (auto& h : headers) {
+            size += vint::vint_size(h.key_size()) + h.key().size_bytes()
+                    + vint::vint_size(h.value_size()) + h.value().size_bytes();
+        }
+        auto key_size = static_cast<int32_t>(key.size_bytes());
+        auto value_size = static_cast<int32_t>(value.size_bytes());
+        return {
+          static_cast<int32_t>(size),
+          model::record_attributes(0),
+          ts_delta,
+          offset_delta,
+          key_size,
+          std::move(key),
+          value_size,
+          std::move(value),
+          std::move(headers)};
+    }
+};


### PR DESCRIPTION
This change parses Protobuf repeated fields into Arrow lists.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
